### PR TITLE
chore: update bazel versions in test matrix

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,7 +1,6 @@
 4.2.4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
-# This also defines which version is used on CI.
 #
-# Note that you should also run integration_tests against other Bazel
-# versions you support.
+# This also defines which version is used on CI and is overwritten in
+# .github/workflows/ci.yaml in a matrix build of { mac, linux } || { v4, v5, v6 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  # because it takes a loooong time
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
@@ -23,7 +27,7 @@ jobs:
           # https://github.com/bazelbuild/rules_docker/issues/1524
           # https://github.com/bazelbuild/rules_docker/issues/1438
           # - windows-latest
-        bazel: [4.2.1, 5.0.0rc4]
+        bazel: [ 4.2.4, 5.4.1, 6.3.2 ]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR updates test matrix to latest releases of the v4, v5, and v6 bazel tool.

default bazel version is also bumped to the latest v4.