### PR TITLE
chore: update internal dependencies: rules_pkg, rules_python

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-4.2.1
+4.2.4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,10 @@ load(":internal_deps.bzl", "rules_jq_internal_deps")
 # Fetch deps needed only locally for development
 rules_jq_internal_deps()
 
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 load("//jq:repositories.bzl", "jq_register_toolchains", "rules_jq_dependencies")
 
 # Fetch our "runtime" dependencies which users need as well

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -12,21 +12,32 @@ def rules_jq_internal_deps():
     maybe(
         http_archive,
         name = "rules_pkg",
+        sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
         ],
-        sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "5868e73107a8e85d8f323806e60cad7283f34b32163ea6ff1020cf27abef6036",
+        strip_prefix = "rules_python-0.25.0",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_python/releases/download/0.25.0/rules_python-0.25.0.tar.gz",
+            "https://github.com/bazelbuild/rules_python/releases/download/0.25.0/rules_python-0.25.0.tar.gz",
+        ],
     )
 
     maybe(
         http_archive,
         name = "build_bazel_integration_testing",
+        sha256 = "f4abdacd838a10a2ac01b813664a53ddf684bb3fedf25dc35765725740cc85e3",
+        strip_prefix = "bazel-integration-testing-7d3e9aee60e2320b1987b871cfaa85b0fca4fdd5",
         urls = [
             "https://github.com/bazelbuild/bazel-integration-testing/archive/7d3e9aee60e2320b1987b871cfaa85b0fca4fdd5.zip",
         ],
-        strip_prefix = "bazel-integration-testing-7d3e9aee60e2320b1987b871cfaa85b0fca4fdd5",
-        sha256 = "f4abdacd838a10a2ac01b813664a53ddf684bb3fedf25dc35765725740cc85e3",
     )
 
     maybe(


### PR DESCRIPTION
Updated:
 - `rules_pkg` and
 -  (forced) `rules_python`
  
.. to versions compatible with:
 - `bazel-4.2.4`
 - `bazel-5.3.1`, and
 - `bazel-6.3.2`